### PR TITLE
Add MFA support for AWS profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ The tool uses the AWS SDK's default credential provider chain, which looks for c
 3. IAM roles for EC2 instances
 4. IAM roles for tasks (ECS/Fargate)
 
+### MFA Support
+
+The tool supports AWS profiles that require Multi-Factor Authentication (MFA). When using a profile with MFA enabled (configured with `mfa_serial` in `~/.aws/config`), the tool will:
+
+1. Automatically detect that MFA is required
+2. Prompt you to enter your MFA token code
+3. Use the token to assume the role and generate temporary credentials
+
+Example AWS config with MFA:
+
+```ini
+[profile my-mfa-profile]
+region = us-east-1
+role_arn = arn:aws:iam::123456789012:role/MyRole
+source_profile = default
+mfa_serial = arn:aws:iam::123456789012:mfa/my-user
+```
+
+Usage with MFA:
+
+```bash
+export AWS_PROFILE=my-mfa-profile
+./elasticache-token -user-id iam-test-user-01 -replication-group-id iam-test-rg-01
+Enter MFA token: 123456
+```
+
 ## License
 
 This project is released under the MIT License.

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.24.5
 require (
 	github.com/aws/aws-sdk-go-v2 v1.37.2
 	github.com/aws/aws-sdk-go-v2/config v1.30.3
+	github.com/aws/aws-sdk-go-v2/credentials v1.18.3
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2/credentials v1.18.3 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.2 // indirect

--- a/pkg/awsutils/client.go
+++ b/pkg/awsutils/client.go
@@ -1,14 +1,34 @@
 package awsutils
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 )
 
+func InteractiveMFATokenProvider() (string, error) {
+	fmt.Fprint(os.Stderr, "Enter MFA token: ")
+	reader := bufio.NewReader(os.Stdin)
+	token, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("failed to read MFA token: %w", err)
+	}
+	return strings.TrimSpace(token), nil
+}
+
 func LoadAWSConfig(ctx context.Context, region string) (aws.Config, error) {
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(region),
+		config.WithAssumeRoleCredentialOptions(func(options *stscreds.AssumeRoleOptions) {
+			options.TokenProvider = InteractiveMFATokenProvider
+		}),
+	)
 	if err != nil {
 		return aws.Config{}, err
 	}


### PR DESCRIPTION
## Summary
- Implemented MFA (Multi-Factor Authentication) support for AWS profiles
- Resolves authentication errors when using profiles with `mfa_serial` configured
- Adds interactive MFA token prompt when authentication requires it

## Problem
When using an AWS profile with MFA enabled (configured with `mfa_serial` in `~/.aws/config`), the tool would fail with:
```
Failed to load AWS configuration: assume role with MFA enabled, but AssumeRoleTokenProvider session option not set
```

## Solution
- Added `InteractiveMFATokenProvider` function to prompt users for MFA tokens
- Configured AWS SDK with `WithAssumeRoleCredentialOptions` to use the MFA token provider
- Updated dependencies to include `stscreds` for handling STS AssumeRole operations

## Changes
- **pkg/awsutils/client.go**: Added MFA token provider and configured AWS SDK to use it
- **go.mod**: Added required `credentials` dependency 
- **README.md**: Added documentation for MFA support with configuration examples

## Test Plan
- [ ] Test with standard AWS profile (no MFA)
- [ ] Test with MFA-enabled profile - should prompt for token
- [ ] Verify token generation works after MFA authentication
- [ ] Confirm documentation is clear and examples work